### PR TITLE
Restricts drag events specifically to the region itself

### DIFF
--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -506,14 +506,16 @@ export class Region {
                 resize = event.target.classList.contains('wavesurfer-handle-start')
                     ? 'start'
                     : 'end';
-            } else {
+            } else if (event.target == event.currentTarget) {
                 regionLeftHalfTime = event.offsetX / this.wavesurfer.params.minPxPerSec;
                 this.isDragging = true;
                 drag = true;
                 resize = false;
             }
-            regionRightHalfTime = this.end - this.start - regionLeftHalfTime;
-            this.wavesurfer.fireEvent('region-move-start', event);
+            if (drag || resize) {
+                regionRightHalfTime = this.end - this.start - regionLeftHalfTime;
+                this.wavesurfer.fireEvent('region-move-start', event);
+            }
         };
         const onUp = (event) => {
             if (event.touches && event.touches.length > 1) {


### PR DESCRIPTION
Previously the mousedown on region checked if the mouse was down on a handle, and set 'resize' and if not assumed 'drag'. This makes that more specific and only assigns drag if the mouse is actually down on the region.