### PR TITLE
Ali/zoom on ready

### DIFF
--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -123,12 +123,6 @@ export default class SelectionPlugin {
                     this.selection.displayRange.start = start || this.selection.displayRange.start;
                     this.selection.displayRange.end = end || this.selection.displayRange.end;
                     this.selection.displayRange.duration = duration || this.selection.displayRange.duration;
-                },
-
-                // override getDuration to return the duration of container
-                getDuration() {
-                    return this.backend.getDuration();
-                    // return this.selection._getDisplayRange().duration;
                 }
             },
             instance: SelectionPlugin

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -175,15 +175,16 @@ export default class SelectionPlugin {
                 });
             }
 
-            const width = this.wavesurfer.drawer.getWidth();
-            const pxPerSec = width / (this._getDisplayRange().duration * this.wavesurfer.params.pixelRatio);
-            this.wavesurfer.zoom(pxPerSec);
-            this.wavesurfer.params.scrollParent = false;
         };
 
         // selection's one allowed region
         this.region = null;
         this._onReady = () => {
+            const width = this.wavesurfer.drawer.getWidth();
+            const pxPerSec = width / (this._getDisplayRange().duration * this.wavesurfer.params.pixelRatio);
+            this.wavesurfer.zoom(pxPerSec);
+
+            this.wavesurfer.params.scrollParent = false;
             this.wrapper = this.wavesurfer.drawer.wrapper;
             this.vertical = this.wavesurfer.drawer.params.vertical;
             if (this.params.dragSelection) {

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -326,6 +326,8 @@ export class Region {
 
     /* Update element's position, width, color. */
     updateRender() {
+        // break out if we currently don't have a backend
+        if (!this.wavesurfer.backend ) {return;}
         // duration varies during loading process, so don't overwrite important data
         const dur = this.wavesurfer.getDuration();
         const displayDuration = this.wavesurfer.getDisplayRange().duration;


### PR DESCRIPTION
integration issues:

* Remove the selection plugin override of wavesurfer.getDuration - it doesn't do anything
* Move the code that zooms the view to the size of the container to onReady. This was part of onBackendCreated, and that's too early for web2 to load the containers reliably. 
* Catch a case where we're reloading a wavesurfer instance. The Region tries to updateRender during the time that the backend is reloading, and this causes crashes - check if the backend exists, and if not, bail out