### PR TITLE
Ali/responsive zooming

### DIFF
--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -51,14 +51,14 @@ document.addEventListener('DOMContentLoaded', function() {
             handleStyle : {
                 left : {
                     left : '12px',
-                    width : '4px',
+                    width : '3px',
                     'background-color':'#FFFFFF',
                     top: '8px',
                     height: '60%'
                 },
                 right : {
                     right : '12px',
-                    width : '4px',
+                    width : '3px',
                     top: '8px',
                     height: '60%',
                     'background-color':'#FFFFFF'

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -41,7 +41,7 @@
             </div>
 
             <div id="demo">
-                <div id="waveform" style="width: 700px; overflow: hidden;">
+                <div id="waveform" style="width: 80%; overflow: hidden;">
                     <!-- Here be waveform -->
                 </div>
 

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -174,11 +174,7 @@ export default class SelectionPlugin {
         // selection's one allowed region
         this.region = null;
         this._onReady = () => {
-            const width = this.wavesurfer.drawer.getWidth();
-            const pxPerSec = width / (this._getDisplayRange().duration * this.wavesurfer.params.pixelRatio);
-            this.wavesurfer.zoom(pxPerSec);
 
-            this.wavesurfer.params.scrollParent = false;
             this.wrapper = this.wavesurfer.drawer.wrapper;
             this.vertical = this.wavesurfer.drawer.params.vertical;
             if (this.params.dragSelection) {

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -333,6 +333,12 @@ export class Region {
         const displayDuration = this.wavesurfer.getDisplayRange().duration;
         const width = this.getWidth();
 
+        const drawerWidth = this.wavesurfer.drawer.getWidth();
+        const pxPerSec = drawerWidth / (displayDuration * this.wavesurfer.params.pixelRatio);
+        this.wavesurfer.params.minPxPerSec = pxPerSec;
+
+        this.wavesurfer.params.scrollParent = false;
+
         let startLimited = this.start - this.wavesurfer.getDisplayRange().start;
         let endLimited = this.end - this.wavesurfer.getDisplayRange().start;
         if (startLimited < 0) {


### PR DESCRIPTION
Updates selection `updateRender` to evaluate the pixels per second. This was previously happening onReady, but that missed cases where the container would change size.
