### PR TITLE
[DE-545] Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Animoto fork of..
+# Animoto fork of wavesurfer. 
+Adds all functionality to the Selection plugin. 
+
+To develop on this fork: 
+* run `yarn start:htmlinit` in a console
+* run `yarn start:plugins` in another console - these together will watch changes in any files you're likely to be changing
+* open http://localhost:8080/example/selectiveCanvas/ - this is the live test page for the Selection plugin. Also includes some documentation.
+* To debug in vscode, debug start the launch config: `Launch Chrome against localhost`. That should allow you to add breakpoints directly in vscode.
+
 # [wavesurfer.js](https://wavesurfer-js.org)
 
 [![npm version](https://img.shields.io/npm/v/wavesurfer.js.svg?style=flat)](https://www.npmjs.com/package/wavesurfer.js)

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     wavesurfer.on('region-update-end', function() {
-        const zones = wavesurfer.getZones();
+        const zones = wavesurfer.getSelectionZones();
         console.log(JSON.stringify(zones));
     });
 

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', function() {
     ).addEventListener('click', function() {
         let region = wavesurfer.selection.region;
 
-        wavesurfer.updateBoundary({start:-10});
+        wavesurfer.updateBoundary({offset:-10});
         region.update({ start : 0 });
         region.update({ end : 6 });
     });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -25,7 +25,6 @@ document.addEventListener('DOMContentLoaded', function() {
         plugins       : [WaveSurfer.selection.create({
             selection : [{}],
             boundaryDuration : 20,
-            boundaryOffset : -5,
             zoneId : "ws1",
             dragThruZones : false
         })],
@@ -35,6 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     wavesurfer.on('ready', () => {
         wavesurfer.addSelection({
+            selectionStart : 10,
             start : 5,
             end   : 10,
             color : 'rgba(0, 28, 142, 1)',
@@ -113,9 +113,11 @@ document.addEventListener('DOMContentLoaded', function() {
     ).addEventListener('click', function() {
         let region = wavesurfer.selection.region;
 
-        wavesurfer.updateBoundary({offset:-10});
-        region.update({ start : 0 });
-        region.update({ end : 6 });
+        wavesurfer.updateSelectionData({
+            selectionStart : 10,
+            audioStart : 0,
+            audioEnd : 6
+        });
     });
 
     document.querySelector(

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -24,8 +24,8 @@ document.addEventListener('DOMContentLoaded', function() {
         fillParent    : false,
         plugins       : [WaveSurfer.selection.create({
             selection : [{}],
-            displayDuration : 20,
-            displayStart : -5,
+            boundaryDuration : 20,
+            boundaryOffset : -5,
             zoneId : "ws1",
             dragThruZones : false
         })],

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', function() {
     ).addEventListener('click', function() {
         let region = wavesurfer.selection.region;
 
-        wavesurfer.updateDisplayRange({start:-10});
+        wavesurfer.updateBoundary({start:-10});
         region.update({ start : 0 });
         region.update({ end : 6 });
     });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -1,5 +1,19 @@
 'use strict';
 
+// vars for zone demo
+const duration = 20;
+const zones = {
+    ws2 : {
+        start : 3,
+        end : 5
+    },
+    ws3 : {
+        start : 12,
+        end : 14
+    }
+};
+
+
 // Create an instance
 var wavesurfer;
 
@@ -24,7 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
         fillParent    : false,
         plugins       : [WaveSurfer.selection.create({
             selection : [{}],
-            boundaryDuration : 20,
+            boundaryDuration : duration,
             zoneId : "ws1",
             dragThruZones : false
         })],
@@ -136,18 +150,25 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelector(
         '[data-action="zones"]'
     ).addEventListener('click', function() {
-        document.querySelector('#zone1').style.visibility = 'visible';
-        document.querySelector('#zone2').style.visibility = 'visible';
-        wavesurfer.updateSelectionZones({
-            ws2 : {
-                start : 3,
-                end : 5
-            },
-            ws3 : {
-                start : 12,
-                end : 14
-            }
-        }
-        );
+        Object.entries(zones).forEach(([id, val]) => {
+            const zoneDiv = document.createElement('div');
+            const container = document.getElementById('zoneContainer');
+            const containerWidth = container.clientWidth;
+            zoneDiv.id = id;
+
+            const width = (val.end - val.start) * (containerWidth / duration);
+            const left = val.start * (containerWidth / duration);
+
+            zoneDiv.style.height = "60px";
+            zoneDiv.style.top = 0;
+            zoneDiv.style.background = "rgba(200, 100, 100, 0.5)";
+            zoneDiv.style.position = "absolute";
+            zoneDiv.style.zIndex = "4";
+            zoneDiv.style.width = `${width}px`;
+            zoneDiv.style.marginLeft = `${left}px`;
+
+            container.append(zoneDiv);
+        });
+        wavesurfer.updateSelectionZones(zones);
     });
 });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -153,19 +153,18 @@ document.addEventListener('DOMContentLoaded', function() {
         Object.entries(zones).forEach(([id, val]) => {
             const zoneDiv = document.createElement('div');
             const container = document.getElementById('zoneContainer');
-            const containerWidth = container.clientWidth;
             zoneDiv.id = id;
 
-            const width = (val.end - val.start) * (containerWidth / duration);
-            const left = val.start * (containerWidth / duration);
+            const width = (val.end - val.start) / duration;
+            const left = val.start / duration;
 
             zoneDiv.style.height = "60px";
             zoneDiv.style.top = 0;
             zoneDiv.style.background = "rgba(200, 100, 100, 0.5)";
             zoneDiv.style.position = "absolute";
             zoneDiv.style.zIndex = "4";
-            zoneDiv.style.width = `${width}px`;
-            zoneDiv.style.marginLeft = `${left}px`;
+            zoneDiv.style.width = `${width * 100}%`;
+            zoneDiv.style.marginLeft = `${left * 100 }%`;
 
             container.append(zoneDiv);
         });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', function() {
         hideScrollbar : false,
         fillParent    : false,
         plugins       : [WaveSurfer.selection.create({
-            selection : [{}],
+            selections : [{}],
             boundaryDuration : duration,
             zoneId : "ws1",
             dragThruZones : false

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -77,9 +77,22 @@ document.addEventListener('DOMContentLoaded', function() {
         console.warn(e);
     });
 
-    wavesurfer.on('region-update-end', function() {
+    wavesurfer.on('region-update-end', function(data) {
         const zones = wavesurfer.getSelectionZones();
-        console.log(JSON.stringify(zones));
+        const {audioEnd, audioStart, boundaryDuration, selectionStart} = data;
+
+        console.log(JSON.stringify({
+            zones,
+            audioEnd,
+            audioStart,
+            boundaryDuration,
+            selectionStart
+        }));
+
+    });
+
+    wavesurfer.on('region-updated', function(data) {
+        console.log(data.selectionStart);
     });
 
     wavesurfer.on('region-overlap-change', function(zone) {

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -98,18 +98,39 @@
 
             <div class="row marketing">
                 <p>
-<pre><code>    wavesurfer = WaveSurfer.create({
-    barGap        : 2,
-    barHeight     : 0.8,
-    barMinHeight  : 2,
-    barWidth      : 2,
-    height        : '72',
+                    Selection Plugin holds the customized code for a "selection" region. It should be combined with the 
+                    SelectiveCanvas renderer as shown below.
+                </p><p>
+                    The SelectiveCanvas renderer inherits from MultiCanvas. Most of the selection code is based on the Region plugin,
+                    with the following updates:
+                </p>
+                <ul>
+                    <li>There is a single region allowed - the 'selection'</li>
+                    <li>The duration of the wave is not the same as the duration of the audio clip, 
+                        instead it is an arbitrary length container within which we want to move and
+                        edit the clip. As an example usage, we have a video of 60seconds and we want to use
+                        this interface to place the audio clip to start at 10 seconds in, playing just the last
+                        5seconds of audio as an overlay - in this case the container duration is 60seconds and 
+                        we keep a value that indicates how much the audio is offset from the start of the container.
+                    </li>
+                    <li>selection can take an object representing multiple 'zones' within the duration, and a zone id.
+                        The zoneId represents the zone region of this instance of wavesurfer, within that zone object.
+                    </li>
+
+                </ul>
+                <p>
+<pre><code>        wavesurfer = WaveSurfer.create({
+    barGap        : 1,
+    barHeight     : 0.9,
+    barMinHeight  : 1,
+    barWidth      : 1,
+    height        : '40',
     container: document.querySelector('#waveform'),
-    cursorColor   : '#ff47d7',
-    cursorWidth   : 2,
-    progressColor : '#ffb2be80',
+    cursorColor   : '#000000',
+    cursorWidth   : 1,
+    progressColor : '#9BA9DF',
     responsive    : false,
-    waveColor     : '#afb2be',
+    waveColor     : '#9BA9DF',
     scrollParent  : false,
     hideScrollbar : false,
     fillParent    : false,
@@ -121,8 +142,10 @@
                 color : 'rgba(155, 169, 223, 0.3)'
             }
         ],
-        displayDuration : 5,
-        displayStart : 0
+        displayDuration : 20,
+        displayStart : -5,
+        zoneId : "ws1",
+        dragThruZones : false
     })],
     renderer      : SelectionPlugin.SelectiveCanvas
 });

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -50,29 +50,11 @@
             </div>
 
             <div id="demo">
-                <div id="zone1" style="
-                    width: 59px;
-                    left: 185px;
-                    height: 80px;
-                    background: rgba(200, 100, 100, 0.5);
-                    top: 104px;
-                    position: absolute;
-                    z-index: 4;
-                    visibility: hidden;
-                     "></div>
-                <div id="zone2" style="
-                    width: 59px;
-                    height: 80px;
-                    background: rgba(200, 100, 100, 0.5);
-                    top: 104px;
-                    position: absolute;
-                    z-index: 4;
-                    left: 445px;
-                    visibility: hidden;
-                 "></div>
-
-                <div id="waveform" style="width: 80%; overflow: hidden; background: grey">
-                    <!-- Here be waveform -->
+                <div id="zoneContainer" style="width: 80%; height: 60px; position: relative;">
+                
+                    <div id="waveform" style="width: 100%; overflow: hidden; background: grey">
+                        <!-- Here be waveform -->
+                    </div>
                 </div>
 
                 <div class="controls">

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -88,11 +88,11 @@
                 </p>
                 <ul>
                     <li>There is a single region allowed - the 'selection'</li>
-                    <li>The duration of the wave is not the same as the duration of the audio clip, 
+                    <li>The duration of the boundary container is not the same as the duration of the audio clip, 
                         instead it is an arbitrary length container within which we want to move and
-                        edit the clip. As an example usage, we have a video of 60seconds and we want to use
+                        edit the clip. As an example usage, we have a video of 20seconds and we want to use
                         this interface to place the audio clip to start at 10 seconds in, playing just the last
-                        5seconds of audio as an overlay - in this case the container duration is 60seconds and 
+                        5seconds of audio as an overlay - in this case the container duration is 20seconds and 
                         we keep a value that indicates how much the audio is offset from the start of the container.
                     </li>
                     <li>selection can take an object representing multiple 'zones' within the duration, and a zone id.
@@ -101,7 +101,8 @@
 
                 </ul>
                 <p>
-<pre><code>        wavesurfer = WaveSurfer.create({
+<pre><code>            
+    wavesurfer = WaveSurfer.create({
     barGap        : 1,
     barHeight     : 0.9,
     barMinHeight  : 1,
@@ -117,20 +118,52 @@
     hideScrollbar : false,
     fillParent    : false,
     plugins       : [WaveSurfer.selection.create({
-        selection : [
-            {
-                start : 0,
-                end   : 5,
-                color : 'rgba(155, 169, 223, 0.3)'
-            }
-        ],
+        selection : [{}],
         boundaryDuration : 20,
-        boundaryOffset : -5,
         zoneId : "ws1",
         dragThruZones : false
     })],
     renderer      : SelectionPlugin.SelectiveCanvas
 });
+
+
+wavesurfer.on('ready', () => {
+    wavesurfer.addSelection({
+        selectionStart : 10,
+        start : 5,
+        end   : 10,
+        color : 'rgba(0, 28, 142, 1)',
+        minLength : 1,
+        cssColor : true,
+        regionStyle : {
+            "border-radius": '13px'
+        },
+        decoratorStyle : {
+            'border-width' : '3px',
+            'border-color' : '#de0010',
+            'border-style' : 'solid',
+            left:'0px',
+            top: '0px',
+            'border-radius': 'inherit'
+        },
+        handleStyle : {
+            left : {
+                left : '12px',
+                width : '3px',
+                'background-color':'#FFFFFF',
+                top: '8px',
+                height: '60%'
+            },
+            right : {
+                right : '12px',
+                width : '3px',
+                top: '8px',
+                height: '60%',
+                'background-color':'#FFFFFF'
+            }
+        }
+
+    });
 </code></pre>
                 </p>
 

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -166,6 +166,56 @@ wavesurfer.on('ready', () => {
     });
 </code></pre>
                 </p>
+                <h3>
+                    Events
+                </h3>
+                <p>
+                    New or augmented events for this plugin:
+                </p>
+                <p>
+                    <pre><code>
+    wavesurfer.on('region-update-end', function(data) {
+        const {audioEnd, audioStart, boundaryDuration, selectionStart} = data;
+        console.log(JSON.stringify({
+            audioEnd,
+            audioStart,
+            boundaryDuration,
+            selectionStart
+        }));
+    });
+
+    wavesurfer.on('region-updated', function(data) {
+        const {audioEnd, audioStart, boundaryDuration, selectionStart} = data;
+        console.log(JSON.stringify({
+            audioEnd,
+            audioStart,
+            boundaryDuration,
+            selectionStart
+        }));
+    });
+
+    wavesurfer.on('region-move-start', function(isDrag) {
+        console.log(`started ${isDrag ? 'dragging' : 'resizing'}`);
+    });
+    
+    wavesurfer.on('region-move-end', function() {
+        console.log('stopped moving');
+    });
+    
+    var currentZones = null;
+    wavesurfer.on('region-overlap-change', function(zone) {
+        if (zone !== currentZones) {
+            if (zone === null) {
+                console.log('not overlapping any zone');
+            } else {
+                console.log(`Overlapping zone ${zone.id} (${zone.start} -> ${zone.end})`);
+            }
+            currentZones = zones;
+        }
+    });
+
+                    </code></pre>
+                </p>
 
             </div>
 

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -118,7 +118,7 @@
     hideScrollbar : false,
     fillParent    : false,
     plugins       : [WaveSurfer.selection.create({
-        selection : [{}],
+        selections : [{}],
         boundaryDuration : 20,
         zoneId : "ws1",
         dragThruZones : false

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -142,8 +142,8 @@
                 color : 'rgba(155, 169, 223, 0.3)'
             }
         ],
-        displayDuration : 20,
-        displayStart : -5,
+        boundaryDuration : 20,
+        boundaryOffset : -5,
         zoneId : "ws1",
         dragThruZones : false
     })],

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -131,8 +131,8 @@ export default class SelectionPlugin {
                     return this.selection._getOverlapZone(start, end);
                 },
 
-                getZones(){
-                    return this.selection._getZones();
+                getSelectionZones(){
+                    return this.selection._getSelectionZones();
                 }
             },
             instance: SelectionPlugin
@@ -270,7 +270,7 @@ export default class SelectionPlugin {
     }
 
     // return all zones
-    _getZones() {
+    _getSelectionZones() {
         const {self, ...zones} = this.selectionZones;
         return {
             ...zones,

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -153,8 +153,7 @@ export default class SelectionPlugin {
 
         this.boundary = {
             offset : this.params.boundaryOffset,
-            duration : this.params.boundaryDuration,
-            end : this.params.boundaryDuration + this.params.boundaryOffset
+            duration : this.params.boundaryDuration
         };
         this.id = params.zoneId;
         this.selectionZones = {};

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -106,8 +106,8 @@ export default class SelectionPlugin {
                     this.selection.disableDragSelection();
                 },
 
-                getDisplayRange() {
-                    return this.selection._getDisplayRange();
+                getBoundary() {
+                    return this.selection._getBoundary();
                 },
 
                 seekTo(progress) {
@@ -115,14 +115,14 @@ export default class SelectionPlugin {
                     // the selection area
                 },
 
-                updateDisplayRange({
+                updateBoundary({
                     start,
                     end,
                     duration
                 }) {
-                    this.selection.displayRange.start = start || this.selection.displayRange.start;
-                    this.selection.displayRange.end = end || this.selection.displayRange.end;
-                    this.selection.displayRange.duration = duration || this.selection.displayRange.duration;
+                    this.selection.boundary.start = start || this.selection.boundary.start;
+                    this.selection.boundary.end = end || this.selection.boundary.end;
+                    this.selection.boundary.duration = duration || this.selection.boundary.duration;
                 },
 
                 updateSelectionZones(selectionZones){
@@ -153,7 +153,7 @@ export default class SelectionPlugin {
         this.maxSelections = 1;
         this.selectionsMinLength = params.selectionsMinLength || null;
 
-        this.displayRange = {
+        this.boundary = {
             start : this.params.displayStart,
             duration : this.params.displayDuration,
             end : this.params.displayDuration + this.params.displayStart
@@ -227,8 +227,8 @@ export default class SelectionPlugin {
 
     getVisualRange({start, end}) {
         return {
-            start: start - this.displayRange.start,
-            end: end - this.displayRange.start
+            start: start - this.boundary.start,
+            end: end - this.boundary.start
         };
     }
 
@@ -241,8 +241,8 @@ export default class SelectionPlugin {
             if (this._updateSelectionZones({self: this.getVisualRange({ start, end })}, fitSelf)) {
                 this.wavesurfer.drawer.updateSelection(selection);
                 this.wavesurfer.drawer.updateDisplayState({
-                    displayStart    : this.displayRange.start,
-                    displayDuration : this.displayRange.duration
+                    displayStart    : this.boundary.start,
+                    displayDuration : this.boundary.duration
                 });
                 this.wavesurfer.drawBuffer();
             }
@@ -262,7 +262,7 @@ export default class SelectionPlugin {
         if (self && fitSelf) {
             const {start, end} = this.getFirstFreeZone(zones, self.start, self.end);
             if (start !== self.start || end !== self.end) {
-                this.displayRange.start = this.region.start - start;
+                this.boundary.start = this.region.start - start;
                 this.region.update({end : this.region.start + end - start});
                 return false;
             }
@@ -287,7 +287,7 @@ export default class SelectionPlugin {
         // sorted list of zones
         let usedZones = Object.values(zones).sort((a, b) => (a.start - b.start) );
         // add contructed 'end' zone
-        usedZones.push({start: this.displayRange.duration});
+        usedZones.push({start: this.boundary.duration});
 
         let freeZones = [];
         let index = 0;
@@ -303,7 +303,7 @@ export default class SelectionPlugin {
         return freeZones;
     }
     // given a list of zones, finds the first range that a new zone can fit in
-    getFirstFreeZone(zones, targetStart = 0, targetEnd = this.displayRange.duration) {
+    getFirstFreeZone(zones, targetStart = 0, targetEnd = this.boundary.duration) {
         const freeZones = this.getFreeZones(zones);
         let start = targetStart;
         let end = targetEnd;
@@ -329,8 +329,8 @@ export default class SelectionPlugin {
         return { start, end };
     }
 
-    _getDisplayRange() {
-        return this.displayRange;
+    _getBoundary() {
+        return this.boundary;
     }
 
     getDeadZones() {
@@ -343,8 +343,8 @@ export default class SelectionPlugin {
         };
         // add contructed 'end' zone
         deadZones.endZone = {
-            start : this.displayRange.duration,
-            end   : this.displayRange.duration
+            start : this.boundary.duration,
+            end   : this.boundary.duration
         };
 
         return deadZones;

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -542,6 +542,8 @@ export default class SelectionPlugin {
         });
         const selection = new this.wavesurfer.Selection(params, this.util, this.wavesurfer);
 
+        selection.elementRef = selection.element.parentElement.lastChild;
+
         // replace region with new selection area
         this.region = selection;
         this.updateCanvasSelection(selection);

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -117,11 +117,9 @@ export default class SelectionPlugin {
 
                 updateBoundary({
                     start,
-                    end,
                     duration
                 }) {
                     this.selection.boundary.offset = start || this.selection.boundary.offset;
-                    this.selection.boundary.end = end || this.selection.boundary.end;
                     this.selection.boundary.duration = duration || this.selection.boundary.duration;
                 },
 

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -120,7 +120,7 @@ export default class SelectionPlugin {
                     end,
                     duration
                 }) {
-                    this.selection.boundary.start = start || this.selection.boundary.start;
+                    this.selection.boundary.offset = start || this.selection.boundary.offset;
                     this.selection.boundary.end = end || this.selection.boundary.end;
                     this.selection.boundary.duration = duration || this.selection.boundary.duration;
                 },
@@ -154,9 +154,9 @@ export default class SelectionPlugin {
         this.selectionsMinLength = params.selectionsMinLength || null;
 
         this.boundary = {
-            start : this.params.displayStart,
-            duration : this.params.displayDuration,
-            end : this.params.displayDuration + this.params.displayStart
+            offset : this.params.boundaryOffset,
+            duration : this.params.boundaryDuration,
+            end : this.params.boundaryDuration + this.params.boundaryOffset
         };
         this.id = params.zoneId;
         this.selectionZones = {};
@@ -227,8 +227,8 @@ export default class SelectionPlugin {
 
     getVisualRange({start, end}) {
         return {
-            start: start - this.boundary.start,
-            end: end - this.boundary.start
+            start: start - this.boundary.offset,
+            end: end - this.boundary.offset
         };
     }
 
@@ -240,9 +240,9 @@ export default class SelectionPlugin {
 
             if (this._updateSelectionZones({self: this.getVisualRange({ start, end })}, fitSelf)) {
                 this.wavesurfer.drawer.updateSelection(selection);
-                this.wavesurfer.drawer.updateDisplayState({
-                    displayStart    : this.boundary.start,
-                    displayDuration : this.boundary.duration
+                this.wavesurfer.drawer.updateBoundaryState({
+                    boundaryOffset    : this.boundary.offset,
+                    boundaryDuration : this.boundary.duration
                 });
                 this.wavesurfer.drawBuffer();
             }
@@ -262,7 +262,7 @@ export default class SelectionPlugin {
         if (self && fitSelf) {
             const {start, end} = this.getFirstFreeZone(zones, self.start, self.end);
             if (start !== self.start || end !== self.end) {
-                this.boundary.start = this.region.start - start;
+                this.boundary.offset = this.region.start - start;
                 this.region.update({end : this.region.start + end - start});
                 return false;
             }

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -116,10 +116,10 @@ export default class SelectionPlugin {
                 },
 
                 updateBoundary({
-                    start,
+                    offset,
                     duration
                 }) {
-                    this.selection.boundary.offset = start || this.selection.boundary.offset;
+                    this.selection.boundary.offset = offset || this.selection.boundary.offset;
                     this.selection.boundary.duration = duration || this.selection.boundary.duration;
                 },
 

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -263,6 +263,8 @@ export default class SelectionPlugin {
     }
 
     _getSelectionData() {
+        if (!this.region || !this.boundary) {return {}; }
+
         const { duration, offset} = this.boundary;
         const {start, end} = this.region;
 

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -14,6 +14,11 @@
  * `initPlugin('selections')`
  * @property {function} formatTimeCallback Allows custom formating for selection tooltip.
  * @property {?number} edgeScrollWidth='5% from container edges' Optional width for edgeScroll to start
+ * @property {number} boundaryDuration Duration of the boundary container in seconds.
+ * @property {?string} zoneId If passing a selectionZones object, this is the id of the zone in that object that represents this selection
+ * @property {?object} selectionZones object representing all selections within this boundary
+ * @property {boolean} dragThruZones If false, dragging logic stops the selection from being dragged through other zones.
+
  */
 
 /**
@@ -31,6 +36,7 @@
  * @property {?object} handleStyle A set of CSS properties used to style the left and right handle.
  * @property {?boolean} preventContextMenu=false Determines whether the context menu is prevented from being opened.
  * @property {boolean} showTooltip=true Enable/disable tooltip displaying start and end times when hovering over selection.
+ * @property {number} selectionStart start point of the selection regions, relative to the boundary container
  */
 
 import {Region} from "./region";
@@ -122,10 +128,26 @@ export default class SelectionPlugin {
                   would have an offset of -2. i.e. when rendering the wave, we start at -2sec relative to the
                   audio and 0sec relative to the container. So: 0sec of the audio is 2sec _into_ the boundary container
                 */
+
+                /**
+                 * getBoundary
+                 *
+                 * @typedef {object} returnObj
+                 * @property {number} returnObj.boundaryDuration duration of boundary container in seconds
+                 * @property {number} returnObj.offset start point of audio wave, relative to boundary start, in seconds
+                 * @returns {returnObj} return object
+                 */
                 getBoundary() {
                     return this.selection._getBoundary();
                 },
 
+                /**
+                 * updateBoundary
+                 *
+                 * @param {object} args args
+                 * @param {number} args.boundaryDuration duration of boundary container in seconds
+                 * @param {number} args.offset start point of audio wave, relative to boundary start, in seconds
+                 */
                 updateBoundary(args) {
                     this.selection._updateBoundary(args);
                 },
@@ -138,10 +160,29 @@ export default class SelectionPlugin {
                 * start - start time in seconds (relative to the boundary container) that the zone starts
                 * end - end time in seconds (relative to the boundary container) that the zone ends
                 */
+
+                /**
+                 * getSelectionZones
+                 *
+                 * @typedef {object} zone
+                 * @property {number} zone.start start point of selection zone, relative to boundary start, in seconds
+                 * @property {number} zone.end end point of selection zone, relative to boundary start, in seconds
+                 * @returns {Record<string, zone>} return object
+                 */
                 getSelectionZones(){
                     return this.selection._getSelectionZones();
                 },
 
+                /**
+                 * updateSelectionZones
+                 *
+                 * @typedef {object} zone
+                 * @property {number} zone.start start point of selection zone, relative to boundary start, in seconds
+                 * @property {number} zone.end end point of selection zone, relative to boundary start, in seconds
+                 *
+                 * @param {Record<string, zone>} selectionZones object of selection zones
+                 * @returns {boolean} return object
+                 */
                 updateSelectionZones(selectionZones){
                     return this.selection._updateSelectionZones(selectionZones);
                 },
@@ -159,12 +200,33 @@ export default class SelectionPlugin {
                 * audioStart - start of audio, relative to the audio clip
                 * audioEnd - end of audio, relative to the audio clip
                 */
+
+                /**
+                 * getSelectionData
+                 *
+                 * @typedef {object} selectionData
+                 * @property {number} selectionData.boundaryDuration duration of boundary container in seconds
+                 * @property {number} selectionData.selectionStart start point of selection zone, relative to boundary start, in seconds
+                 * @property {number} selectionData.audioStart start point of selection audio region, relative to the audio itself, in seconds
+                 * @property {number} selectionData.audioEnd end point of selection audio region, relative to the audio itself, in seconds
+                 *
+                 * @returns {selectionData} return object
+                 */
                 getSelectionData() {
                     return this.selection._getSelectionData();
                 },
 
+                /**
+                 * updateSelectionData
+                 *
+                 * @param {object} args args
+                 * @param {?number} args.boundaryDuration duration of boundary container in seconds
+                 * @param {?number} args.selectionStart start point of selection zone, relative to boundary start, in seconds
+                 * @param {?number} args.audioStart start point of selection audio region, relative to the audio itself, in seconds
+                 * @param {?number} args.audioEnd end point of selection audio region, relative to the audio itself, in seconds
+                 */
                 updateSelectionData(args) {
-                    return this.selection._updateSelectionData(args);
+                    this.selection._updateSelectionData(args);
                 }
             },
             instance: SelectionPlugin

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -29,6 +29,8 @@ export class Region {
         this.resize =
             params.resize === undefined ? true : Boolean(params.resize);
         this.drag = params.drag === undefined ? true : Boolean(params.drag);
+        // stop event propagation in this region
+        this.stopPropagationHere = params.stopPropagationHere === undefined ? true : Boolean(params.stopPropagationHere);
         // reflect resize and drag state of region for region-updated listener
         this.isResizing = false;
         this.isDragging = false;
@@ -502,7 +504,7 @@ export class Region {
 
             // stop the event propagation, if this region is resizable or draggable
             // and the event is therefore handled here.
-            if (this.drag || this.resize) {
+            if (this.stopPropagationHere && (this.drag || this.resize)) {
                 event.stopPropagation();
             }
 

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -549,7 +549,7 @@ export class Region {
 
             if (drag && updated && lastGoodRange.start !== startRange.start && lastGoodRange.end !== startRange.end) {
                 this.wavesurfer.updateBoundary({
-                    start :     this.start - lastGoodRange.start
+                    offset :     this.start - lastGoodRange.start
                 });
                 this.update({});
                 this.updateRender();
@@ -732,7 +732,7 @@ export class Region {
         };
 
         this.wavesurfer.updateBoundary({
-            start :     this.wavesurfer.getBoundary().offset - delta
+            offset :     this.wavesurfer.getBoundary().offset - delta
         });
         this.update({
             start: this.start,

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -93,11 +93,12 @@ export class Region {
         this.wavesurfer.fireEvent('region-created', this);
     }
 
-    /* Returns this, with added boundaryOffset */
-    withDisplay() {
+    /* Returns this, with added SelectionData */
+    withSelectionData() {
+        const selectionData = this.wavesurfer.getSelectionData();
         return {
             ...this,
-            boundaryOffset : this.wavesurfer.getBoundary().offset
+            ...selectionData
         };
     }
 
@@ -143,7 +144,7 @@ export class Region {
 
         this.updateRender();
         this.fireEvent('update');
-        this.wavesurfer.fireEvent('region-updated', this.withDisplay(), eventParams);
+        this.wavesurfer.fireEvent('region-updated', this.withSelectionData(), eventParams);
     }
 
     /* Remove a single region. */
@@ -568,7 +569,7 @@ export class Region {
                 updated = false;
                 this.util.preventClick();
                 this.fireEvent('update-end', event);
-                this.wavesurfer.fireEvent('region-update-end', this.withDisplay(), event);
+                this.wavesurfer.fireEvent('region-update-end', this.withSelectionData(), event);
             }
 
             if (this.element.isEqualNode(event.srcElement)) {

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -93,11 +93,11 @@ export class Region {
         this.wavesurfer.fireEvent('region-created', this);
     }
 
-    /* Returns this, with added displayStart */
+    /* Returns this, with added boundaryOffset */
     withDisplay() {
         return {
             ...this,
-            displayStart : this.wavesurfer.getBoundary().start
+            boundaryOffset : this.wavesurfer.getBoundary().offset
         };
     }
 
@@ -330,25 +330,25 @@ export class Region {
         if (!this.wavesurfer.backend ) {return;}
         // duration varies during loading process, so don't overwrite important data
         const dur = this.wavesurfer.getDuration();
-        const displayDuration = this.wavesurfer.getBoundary().duration;
+        const boundaryDuration = this.wavesurfer.getBoundary().duration;
         const width = this.getWidth();
 
         const drawerWidth = this.wavesurfer.drawer.getWidth();
         // if we cannot get drawerWidth, we shouldn't set minPxPerSec using it.
         if (drawerWidth !== 0) {
-            const pxPerSec = drawerWidth / (displayDuration * this.wavesurfer.params.pixelRatio);
+            const pxPerSec = drawerWidth / (boundaryDuration * this.wavesurfer.params.pixelRatio);
             this.wavesurfer.params.minPxPerSec = pxPerSec;
         }
 
-        let startLimited = this.start - this.wavesurfer.getBoundary().start;
-        let endLimited = this.end - this.wavesurfer.getBoundary().start;
+        let startLimited = this.start - this.wavesurfer.getBoundary().offset;
+        let endLimited = this.end - this.wavesurfer.getBoundary().offset;
         if (startLimited < 0) {
             startLimited = 0;
             endLimited = endLimited - startLimited;
         }
-        if (endLimited > displayDuration) {
-            endLimited = displayDuration;
-            startLimited = displayDuration - (endLimited - startLimited);
+        if (endLimited > boundaryDuration) {
+            endLimited = boundaryDuration;
+            startLimited = boundaryDuration - (endLimited - startLimited);
         }
 
         if (this.minLength != null) {
@@ -506,7 +506,7 @@ export class Region {
             }
 
             startProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const displayStart = this.wavesurfer.getBoundary().start;
+            const boundaryOffset = this.wavesurfer.getBoundary().offset;
             // Store the selected startTime we begun dragging or resizing
             startTime = this.regionsUtil.getRegionSnapToGridValue(
                 startProportion * duration
@@ -615,7 +615,7 @@ export class Region {
             }
 
             const timeProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const displayStart = this.wavesurfer.getBoundary().start;
+            const boundaryOffset = this.wavesurfer.getBoundary().offset;
 
             let time = this.regionsUtil.getRegionSnapToGridValue(
                 timeProportion * duration
@@ -732,7 +732,7 @@ export class Region {
         };
 
         this.wavesurfer.updateBoundary({
-            start :     this.wavesurfer.getBoundary().start - delta
+            start :     this.wavesurfer.getBoundary().offset - delta
         });
         this.update({
             start: this.start,
@@ -768,7 +768,7 @@ export class Region {
      */
     onResize(delta, direction) {
         const audioDuration = this.wavesurfer.getDuration();
-        const displayDuration = this.wavesurfer.getBoundary().duration;
+        const boundaryDuration = this.wavesurfer.getBoundary().duration;
         const eventParams = {
             action: 'resize',
             direction: direction === 'start' ? 'left' : 'right'

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -97,7 +97,7 @@ export class Region {
     withDisplay() {
         return {
             ...this,
-            displayStart : this.wavesurfer.getDisplayRange().start
+            displayStart : this.wavesurfer.getBoundary().start
         };
     }
 
@@ -330,7 +330,7 @@ export class Region {
         if (!this.wavesurfer.backend ) {return;}
         // duration varies during loading process, so don't overwrite important data
         const dur = this.wavesurfer.getDuration();
-        const displayDuration = this.wavesurfer.getDisplayRange().duration;
+        const displayDuration = this.wavesurfer.getBoundary().duration;
         const width = this.getWidth();
 
         const drawerWidth = this.wavesurfer.drawer.getWidth();
@@ -340,8 +340,8 @@ export class Region {
             this.wavesurfer.params.minPxPerSec = pxPerSec;
         }
 
-        let startLimited = this.start - this.wavesurfer.getDisplayRange().start;
-        let endLimited = this.end - this.wavesurfer.getDisplayRange().start;
+        let startLimited = this.start - this.wavesurfer.getBoundary().start;
+        let endLimited = this.end - this.wavesurfer.getBoundary().start;
         if (startLimited < 0) {
             startLimited = 0;
             endLimited = endLimited - startLimited;
@@ -493,7 +493,7 @@ export class Region {
         const buffer = bufferPx / this.wavesurfer.params.minPxPerSec;
 
         const onDown = (event) => {
-            const duration = this.wavesurfer.getDisplayRange().duration;
+            const duration = this.wavesurfer.getBoundary().duration;
             if (event.touches && event.touches.length > 1) {
                 return;
             }
@@ -506,7 +506,7 @@ export class Region {
             }
 
             startProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const displayStart = this.wavesurfer.getDisplayRange().start;
+            const displayStart = this.wavesurfer.getBoundary().start;
             // Store the selected startTime we begun dragging or resizing
             startTime = this.regionsUtil.getRegionSnapToGridValue(
                 startProportion * duration
@@ -548,7 +548,7 @@ export class Region {
             }
 
             if (drag && updated && lastGoodRange.start !== startRange.start && lastGoodRange.end !== startRange.end) {
-                this.wavesurfer.updateDisplayRange({
+                this.wavesurfer.updateBoundary({
                     start :     this.start - lastGoodRange.start
                 });
                 this.update({});
@@ -601,7 +601,7 @@ export class Region {
             }
         };
         const onMove = (event) => {
-            const duration = this.wavesurfer.getDisplayRange().duration;
+            const duration = this.wavesurfer.getBoundary().duration;
             let orientedEvent = this.util.withOrientation(event, this.vertical);
 
             if (event.touches && event.touches.length > 1) {
@@ -615,7 +615,7 @@ export class Region {
             }
 
             const timeProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const displayStart = this.wavesurfer.getDisplayRange().start;
+            const displayStart = this.wavesurfer.getBoundary().start;
 
             let time = this.regionsUtil.getRegionSnapToGridValue(
                 timeProportion * duration
@@ -629,7 +629,7 @@ export class Region {
             if (drag) {
 
                 // To maintain relative cursor start point while dragging
-                const maxEnd = this.wavesurfer.getDisplayRange().duration;
+                const maxEnd = this.wavesurfer.getBoundary().duration;
                 if (time > maxEnd - regionRightHalfTime) {
                     time = maxEnd - regionRightHalfTime;
                 }
@@ -731,8 +731,8 @@ export class Region {
             action: 'drag'
         };
 
-        this.wavesurfer.updateDisplayRange({
-            start :     this.wavesurfer.getDisplayRange().start - delta
+        this.wavesurfer.updateBoundary({
+            start :     this.wavesurfer.getBoundary().start - delta
         });
         this.update({
             start: this.start,
@@ -768,7 +768,7 @@ export class Region {
      */
     onResize(delta, direction) {
         const audioDuration = this.wavesurfer.getDuration();
-        const displayDuration = this.wavesurfer.getDisplayRange().duration;
+        const displayDuration = this.wavesurfer.getBoundary().duration;
         const eventParams = {
             action: 'resize',
             direction: direction === 'start' ? 'left' : 'right'

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -507,7 +507,6 @@ export class Region {
             }
 
             startProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const boundaryOffset = this.wavesurfer.getBoundary().offset;
             // Store the selected startTime we begun dragging or resizing
             startTime = this.regionsUtil.getRegionSnapToGridValue(
                 startProportion * duration
@@ -616,7 +615,6 @@ export class Region {
             }
 
             const timeProportion = this.wavesurfer.drawer.handleEvent(event, true);
-            const boundaryOffset = this.wavesurfer.getBoundary().offset;
 
             let time = this.regionsUtil.getRegionSnapToGridValue(
                 timeProportion * duration
@@ -769,7 +767,6 @@ export class Region {
      */
     onResize(delta, direction) {
         const audioDuration = this.wavesurfer.getDuration();
-        const boundaryDuration = this.wavesurfer.getBoundary().duration;
         const eventParams = {
             action: 'resize',
             direction: direction === 'start' ? 'left' : 'right'

--- a/src/plugin/selection/selectivecanvas.js
+++ b/src/plugin/selection/selectivecanvas.js
@@ -163,7 +163,7 @@ export default class SelectiveCanvas extends MultiCanvas {
             totalWidth / (this.maxCanvasElementWidth + this.overlap)
         );
         const displayPixelWidth = (
-            (this.selection?.wavesurfer.getDisplayRange().duration || 0)
+            (this.selection?.wavesurfer.getBoundary().duration || 0)
             * this.params.minPxPerSec
             * this.params.pixelRatio
         );

--- a/src/plugin/selection/selectivecanvas.js
+++ b/src/plugin/selection/selectivecanvas.js
@@ -57,8 +57,8 @@ export default class SelectiveCanvas extends MultiCanvas {
         // selection reference
         this.selection = null;
 
-        this.displayStart = 0;
-        this.displayDuration = 0;
+        this.boundaryOffset = 0;
+        this.boundaryDuration = 0;
 
         /**
          * Class used to generate entries.
@@ -136,12 +136,12 @@ export default class SelectiveCanvas extends MultiCanvas {
         this.selection = selection;
     }
 
-    updateDisplayState({
-        displayStart,
-        displayDuration
+    updateBoundaryState({
+        boundaryOffset,
+        boundaryDuration
     }) {
-        this.displayDuration = displayDuration || this.displayDuration,
-        this.displayStart = displayStart !== undefined ? displayStart : this.displayStart;
+        this.boundaryDuration = boundaryDuration || this.boundaryDuration,
+        this.boundaryOffset = boundaryOffset !== undefined ? boundaryOffset : this.boundaryOffset;
     }
 
     /**
@@ -240,7 +240,7 @@ export default class SelectiveCanvas extends MultiCanvas {
                     last = Math.floor(this.selection.end * this.params.minPxPerSec * this.params.pixelRatio);
                     peakIndex = Math.floor(this.selection.start * this.params.minPxPerSec * this.params.pixelRatio);
                 }
-                const displayOffset = this.displayStart * this.params.minPxPerSec * this.params.pixelRatio;
+                const displayOffset = this.boundaryOffset * this.params.minPxPerSec * this.params.pixelRatio;
 
                 const hideBarEnds = 1;
                 const adjustedDrawStart = peakIndex + step * hideBarEnds;
@@ -466,7 +466,7 @@ export default class SelectiveCanvas extends MultiCanvas {
      * @param {number} position X-offset of progress position in pixels
      */
     updateProgress(position) {
-        const displayOffset = this.displayStart * this.params.minPxPerSec;
+        const displayOffset = this.boundaryOffset * this.params.minPxPerSec;
         const offsetPosition = position - displayOffset;
         this.style(this.progressWave, { width: offsetPosition + 'px' });
     }


### PR DESCRIPTION
Breakingish change and refactor. 

Updates:
* Reduce the amount of copied code from wavesurfer by having `SelectionCanvas` inherit from `MultiCanvas` instead of `Drawer`. `SelectionCanvas` was based on `MultiCanvas` anyway, and I always meant to do this once I was more sure about what functions I was going to be overwriting.
* Update some of the internal naming and concepts to something that makes more sense now that we have support for zones
  * The visible area that the wave fits into is now the 'boundary' (we use this for the video)
    * boundaryDuration is the length of the area in seconds (video length)
    * boundaryOffset is an internal value used for calculating where to put the wave. There's no need for AudioTrimEditor to know about this value, so I added:
  * 'selectionData' which is largely an interface to get and set the things we care about outside wavesurfer. Getting and setting (i.e. creating and updating wavesurfer) will now use these:
    * boundaryDuration - boundary duration from above (video length)
    * selectionStart - start of selection region, relative to the boundary (startTimeOffset)
    * audioStart - start of audio, relative to the audio clip (startTrimTime)
    * audioEnd - end of audio, relative to the audio clip (endTrimTime)
* Updates to the example test page at http://localhost:8080/example/selectiveCanvas/ to make the test zones a bit more dynamic and not reliant on a specific page width.
* We've struggled to determine if a click has happened in the selection region, because we stop propagating events in there. I've added a selection option to turn that behavior off - so that events can pass through.
* Also - the reference that we have to the selection region element is a Proxy, which made it harder to test some of those mouse events. I've added an `elementRef` to the returned selection region, that is a reference to the element itself.