### PR TITLE
Ali/improve zone overlapping

### DIFF
--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -10,6 +10,10 @@ const zones = {
     ws3 : {
         start : 12,
         end : 14
+    },
+    ws4 : {
+        start : 8,
+        end : 10
     }
 };
 
@@ -106,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     wavesurfer.on('region-updated', function(data) {
-        console.log(data.selectionStart);
+        //console.log(data.selectionStart);
     });
 
     wavesurfer.on('region-overlap-change', function(zone) {

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -493,6 +493,7 @@ export default class SelectionPlugin {
     _getOverlapZone(start, end = start) {
         const zones = this.getDeadZones();
         const zoneIds = Object.keys(zones);
+        let overlapZones = {};
         for (let i = 0; i < zoneIds.length; i += 1){
             const id = zoneIds[i];
             if (
@@ -503,10 +504,13 @@ export default class SelectionPlugin {
                 // zone is entirely within selection
                 (zones[id].start >= start && zones[id].end <= end)
             ) {
-                return {...zones[id], id: id};
+                overlapZones[id] = {...zones[id]};
             }
         }
-        return null;
+        if (Object.keys(overlapZones).length === 0) {
+            return null;
+        }
+        return overlapZones;
     }
 
     /**


### PR DESCRIPTION
## Improving logic for multiple zones. 

Previously I was determining if the dragged region would speculatively overlap another zone and would butt the region up against that zone. HOWEVER, if you kept 'dragging' even though nothing moved, we started to register that we would speculatively overlap another zone, or multiple zones. Now I'm keeping track of any zones that have been overlapped during a drag session, and butting against the closest zone to the starting point. 

## Improved resizing

Existing logic for resizing regions doesn't allow resizing to an invalid state, but only does so by stopping processing. However, that lets wavesurfer update the mouse drag cursor and can cause some weird stuff.
![2022-05-04_11-14-20 (1)](https://user-images.githubusercontent.com/739776/166726365-b06e5c7d-ac5c-457b-a5ab-2ae5d9efacb1.gif)
![2022-05-04_12-22-33 (1)](https://user-images.githubusercontent.com/739776/166726392-911186cd-20b8-40ee-ab12-b850f476462e.gif)
This moves resize boundary logic into onMove so that we can keep a consistent cursor position:
![2022-05-04_12-13-52 (1)](https://user-images.githubusercontent.com/739776/166726573-11dce061-b075-4e88-83fe-02e194dac2a8.gif)

