### PR TITLE
Ali/dogfooding feedback

### DIFF
--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
         let region = wavesurfer.selection.region;
 
         wavesurfer.updateSelectionData({
-            selectionStart : 10,
+            selectionStart : 0,
             audioStart : 0,
             audioEnd : 6
         });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     wavesurfer.on('ready', () => {
         wavesurfer.addSelection({
-            selectionStart : 10,
+            selectionStart : 11.564,
             start : 5,
             end   : 10,
             color : 'rgba(0, 28, 142, 1)',

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -56,7 +56,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     wavesurfer.on('ready', () => {
         wavesurfer.addSelection({
-            selectionStart : 11.564,
+            selectionStart : 10,
             start : 5,
             end   : 10,
             color : 'rgba(0, 28, 142, 1)',
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
         let region = wavesurfer.selection.region;
 
         wavesurfer.updateSelectionData({
-            selectionStart : 0,
+            selectionStart : 11.564,
             audioStart : 0,
             audioEnd : 6
         });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -160,9 +160,9 @@ document.addEventListener('DOMContentLoaded', function() {
         let region = wavesurfer.selection.region;
 
         wavesurfer.updateSelectionData({
-            selectionStart : 11.564,
+            selectionStart : 0,
             audioStart : 0,
-            audioEnd : 6
+            audioEnd : 4
         });
     });
 

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -493,18 +493,6 @@ export default class SelectionPlugin {
 
     getDeadZones() {
         let {self, ...deadZones} = this.selectionZones;
-
-        // add contructed 'start' zone
-        deadZones.startZone = {
-            start : 0,
-            end   : 0
-        };
-        // add contructed 'end' zone
-        deadZones.endZone = {
-            start : this.boundary.duration,
-            end   : this.boundary.duration
-        };
-
         return deadZones;
     }
 
@@ -527,7 +515,7 @@ export default class SelectionPlugin {
                 // selection overlaps the left side of a zone
                 (zones[id].start <= end && zones[id].end > end) ||
                 // zone is entirely within selection (not start or end zone)
-                (!['startZone', 'endZone'].includes(id) && zones[id].start >= start && zones[id].end <= end) ||
+                (zones[id].start >= start && zones[id].end <= end) ||
                 // zone exactly equals the selection
                 (zones[id].start === start && zones[id].end === end)
             ) {

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -526,8 +526,8 @@ export default class SelectionPlugin {
                 (zones[id].start < start && zones[id].end >= start) ||
                 // selection overlaps the left side of a zone
                 (zones[id].start <= end && zones[id].end > end) ||
-                // zone is entirely within selection
-                (zones[id].start >= start && zones[id].end <= end) ||
+                // zone is entirely within selection (not start or end zone)
+                (!['startZone', 'endZone'].includes(id) && zones[id].start >= start && zones[id].end <= end) ||
                 // zone exactly equals the selection
                 (zones[id].start === start && zones[id].end === end)
             ) {

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -527,7 +527,7 @@ export default class SelectionPlugin {
                 // selection overlaps the left side of a zone
                 (zones[id].start <= end && zones[id].end > end) ||
                 // zone is entirely within selection
-                (zones[id].start > start && zones[id].end < end) ||
+                (zones[id].start >= start && zones[id].end <= end) ||
                 // zone exactly equals the selection
                 (zones[id].start === start && zones[id].end === end)
             ) {

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -341,7 +341,7 @@ export default class SelectionPlugin {
 
         return {
             boundaryDuration : duration,
-            selectionStart : start - offset,
+            selectionStart : this.util.msRound(start - offset),
             audioStart : start,
             audioEnd : end
         };
@@ -383,8 +383,8 @@ export default class SelectionPlugin {
 
     getVisualRange({start, end}) {
         return {
-            start: start - this.boundary.offset,
-            end: end - this.boundary.offset
+            start: this.util.msRound(start - this.boundary.offset),
+            end: this.util.msRound(end - this.boundary.offset)
         };
     }
 

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -700,7 +700,10 @@ export class Region {
                     time = minStart + regionLeftHalfTime;
                 }
 
-                newRange = {start: time - regionLeftHalfTime, end : time + regionRightHalfTime};
+                newRange = {
+                    start: this.wavesurfer.selection.util.msRound(time - regionLeftHalfTime),
+                    end : this.wavesurfer.selection.util.msRound(time + regionRightHalfTime)
+                };
                 const overlapZones = this.wavesurfer.getOverlapZone(newRange.start, newRange.end);
                 setZoneOverlap( overlapZones);
 
@@ -744,7 +747,10 @@ export class Region {
                 }
 
                 // Check if we're resizing into another zone
-                newRange = {...startRange, start: time - regionLeftHalfTime};
+                newRange = {
+                    ...startRange,
+                    start: this.wavesurfer.selection.util.msRound(time - regionLeftHalfTime)
+                };
                 const overlapZones = this.wavesurfer.getOverlapZone(newRange.start, newRange.end);
                 if (overlapZones) {
                     const bumperValue = nextZoneBoundary(overlapZones, startTime, -1); // the overlapzone that we're bumping up against
@@ -770,7 +776,10 @@ export class Region {
                     time = startRange.start + audioDuration - this.start - regionRightHalfTime;
                 }
 
-                newRange = {...startRange, end : time + regionRightHalfTime};
+                newRange = {
+                    ...startRange,
+                    end : this.wavesurfer.selection.util.msRound(time + regionRightHalfTime)
+                };
                 const overlapZones = this.wavesurfer.getOverlapZone(newRange.start, newRange.end);
                 if (overlapZones) {
                     const bumperValue = nextZoneBoundary(overlapZones, startTime, 1); // the overlapzone that we're bumping up against

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -650,9 +650,6 @@ export class Region {
                 comparison = (a, b) => (a > b);
             }
             let workingArray = Object.values(zones).map((zone) => zone[boundaryKey]);
-            if (workingArray.length == 1) {
-                return workingArray[0];
-            }
 
             workingArray.sort(sorter);
             for (let i = 0; i < workingArray.length; i += 1) {
@@ -660,7 +657,7 @@ export class Region {
                     return workingArray[i];
                 }
             }
-
+            return null;
         };
         const onMove = (event) => {
             const duration = this.wavesurfer.getBoundary().duration;
@@ -712,9 +709,9 @@ export class Region {
                         const bumperValue = nextZoneBoundary({...zoneOverlap, ...overlapZones}, startTime, time - startTime); // the overlapzone that we're bumping up against
                         // we're dragging right
                         if (time > startTime) {
-                            time = bumperValue - regionRightHalfTime - buffer;
+                            time = bumperValue !== null ? bumperValue - regionRightHalfTime - buffer : time;
                         } else {
-                            time = bumperValue + regionLeftHalfTime + buffer;
+                            time = bumperValue !== null ? bumperValue + regionLeftHalfTime + buffer : time;
                         }
                     }
                 }

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -617,8 +617,6 @@ export class Region {
             let updateZones = {...zoneOverlap};
 
             Object.entries(zones).forEach(([id, zone]) => {
-                if (['startZone', 'endZone'].includes(id)) { return;}
-
                 if (!updateZones[id]) {
                     updateZones[id] = {...zone};
                     updateFlag = true;


### PR DESCRIPTION
Overlapping logic summary: 
https://miro.com/app/board/uXjVOEXq7G0=/?moveToWidget=3458764525661291763&cot=14

All the addressed are variations on this e.g.: 

![image](https://user-images.githubusercontent.com/739776/169087504-5f919a66-5c3b-4b72-8ce2-946b5a51bd21.png)
If we're overlapping a zone, and we're moving right, we want to butt up against the left side of the zone. 

![image](https://user-images.githubusercontent.com/739776/169086413-3e6f6594-0b8c-4909-a288-85602209280d.png)
BUT if we _think_ this selection is overlapping this zone and we're moving right, we can get an error where the selection jumps to butt up against the left side of the zone. 

### Precision
This can happen due to js floating point precision errors. I'd tackled a lot of these by creating a rounding util to round the values to 3 dp and used it in all locations that store seconds values. 

This PR applies that util to some other areas where second values were being calculated on the fly. I've surveyed while using the example page and breaking execution on e.g. `self.start.toString().split('.')[1].length > 3` - any cases where the precision is finer than that -- I think I've caught them all. 

A cleaner solution might be to replace every location that uses a seconds value with a millisecond integer and never have to deal with floating point seconds at all. I'm not at all sure how much of an effort that would be and how much re-writing of wavesurfer code that would require. 

### Specifically butting against the wrong zone.
When we encounter an overlap, we now ensure that the zone we want to butt up against is actually in the direction that we're moving. 



