### PR TITLE
configurable values for region gap and bars to hide at end of region

### DIFF
--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -48,7 +48,9 @@ document.addEventListener('DOMContentLoaded', function() {
             selections : [{}],
             boundaryDuration : duration,
             zoneId : "ws1",
-            dragThruZones : false
+            dragThruZones : false,
+            hideBarEnds: 2,
+            regionGap: 4
         })],
         renderer      : SelectionPlugin.SelectiveCanvas
     });

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
             zoneId : "ws1",
             dragThruZones : false,
             hideBarEnds: 2,
-            regionGap: 4
+            regionGap: 2
         })],
         renderer      : SelectionPlugin.SelectiveCanvas
     });

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -37,6 +37,8 @@
  * @property {?boolean} preventContextMenu=false Determines whether the context menu is prevented from being opened.
  * @property {boolean} showTooltip=true Enable/disable tooltip displaying start and end times when hovering over selection.
  * @property {number} selectionStart start point of the selection regions, relative to the boundary container
+ * @property {number} hideBarEnds number of bars of the waveform to hide at the beginning and end of a region
+ * @property {number} regionGap spacer to apply to regions to allow a visual gap without having an actual gap
  */
 
 import {Region} from "./region";

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -254,6 +254,9 @@ export default class SelectionPlugin {
         this.maxSelections = 1;
         this.selectionsMinLength = params.selectionsMinLength || null;
 
+        this.wavesurfer.params.hideBarEnds = params.hideBarEnds || 1;
+        this.regionGap = params.regionGap || 0;
+
         this.boundary = {
             offset : this.params.boundaryOffset || 0,
             duration : this.params.boundaryDuration

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -291,7 +291,7 @@ export class Region {
                 width: 'inherit',
                 height: 'inherit',
                 'pointer-events': 'none',
-                'z-index':6
+                'z-index': 6
             };
 
             // Merge defaultDecoratorCSS properties.
@@ -365,8 +365,9 @@ export class Region {
         if (this.element != null) {
             // Calculate the left and width values of the region such that
             // no gaps appear between regions.
-            const left = Math.round((startLimited / dur) * width);
-            const regionWidth = Math.round((endLimited / dur) * width) - left;
+            const regionGapHalf = this.wavesurfer.selection.regionGap / 2;
+            const left = Math.round((startLimited / dur) * width + regionGapHalf);
+            const regionWidth = Math.round((endLimited / dur) * width - regionGapHalf) - left;
 
             this.style(this.element, {
                 left: left + 'px',

--- a/src/plugin/selection/selectivecanvas.js
+++ b/src/plugin/selection/selectivecanvas.js
@@ -242,7 +242,7 @@ export default class SelectiveCanvas extends MultiCanvas {
                 }
                 const displayOffset = this.boundaryOffset * this.params.minPxPerSec * this.params.pixelRatio;
 
-                const hideBarEnds = 1;
+                const hideBarEnds = this.params.hideBarEnds;
                 const adjustedDrawStart = peakIndex + step * hideBarEnds;
                 const adjustedDrawEnd = last - step * hideBarEnds;
 


### PR DESCRIPTION
Allows configuring of 
`hideBarEnds`:  number of bars of the waveform to hide at the beginning and end of a region
`regionGap` : spacer to apply to regions to allow a visual gap without having an actual gap