### PR TITLE
[DE-1260] minDisplay length

### DIFF
--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
             end   : 10,
             color : 'rgba(0, 28, 142, 1)',
             minLength : 1,
-            minDisplayLength : 0.5,
+            minDisplayLength : 0.3,
             cssColor : false,
             regionStyle : {
                 "border-radius": '13px'

--- a/example/selectiveCanvas/app.js
+++ b/example/selectiveCanvas/app.js
@@ -63,7 +63,8 @@ document.addEventListener('DOMContentLoaded', function() {
             end   : 10,
             color : 'rgba(0, 28, 142, 1)',
             minLength : 1,
-            cssColor : true,
+            minDisplayLength : 0.5,
+            cssColor : false,
             regionStyle : {
                 "border-radius": '13px'
             },
@@ -102,13 +103,13 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     wavesurfer.on('seek', () => {
-        document.getElementById("regionTime").innerHTML = `Region Time = ${format(wavesurfer.getCurrentTime())}`;
-        document.getElementById("boundaryTime").innerHTML = `Boundary Time = ${format(wavesurfer.getBoundaryTime())}`;
+        document.getElementById("regionTime").innerHTML = `Cursor Time within Region = ${format(wavesurfer.getCurrentTime())}`;
+        document.getElementById("boundaryTime").innerHTML = `Cursor Time within Boundary = ${format(wavesurfer.getBoundaryTime())}`;
     });
 
     wavesurfer.on('audioprocess', () => {
-        document.getElementById("regionTime").innerHTML = `Region Time = ${format(wavesurfer.getCurrentTime())}`;
-        document.getElementById("boundaryTime").innerHTML = `Boundary Time = ${format(wavesurfer.getBoundaryTime())}`;
+        document.getElementById("regionTime").innerHTML = `Cursor Time within Region = ${format(wavesurfer.getCurrentTime())}`;
+        document.getElementById("boundaryTime").innerHTML = `Cursor Time within Boundary = ${format(wavesurfer.getBoundaryTime())}`;
     });
 
 
@@ -159,12 +160,14 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelector(
         '[data-action="update"]'
     ).addEventListener('click', function() {
-        let region = wavesurfer.selection.region;
+        const selectionStart = document.getElementById('selectionStart').value;
+        const audioStart = document.getElementById('audioStart').value;
+        const audioEnd = document.getElementById('audioEnd').value;
 
         wavesurfer.updateSelectionData({
-            selectionStart : 0,
-            audioStart : 0,
-            audioEnd : 4
+            selectionStart,
+            audioStart,
+            audioEnd
         });
     });
 

--- a/example/selectiveCanvas/index.html
+++ b/example/selectiveCanvas/index.html
@@ -36,6 +36,25 @@
             .overlapped {
               background-color: brown;
             }
+            .btn {
+                height : 30px;
+            }
+            .controls {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-evenly;
+            }
+            .valButton {
+                display: flex;
+                flex-direction: column;
+                width: 170px;
+            }
+            [data-region-small-bar] > .wavesurfer-handle {
+                display : none
+            }
+            [data-region-small-bar] > .wavesurfer-selection-decorator {
+                display : none
+            }
             </style>
     </head>
 
@@ -57,10 +76,10 @@
                     </div>
                 </div>
                 <div id="regionTime">
-                    Region Time = 0.00
+                    Cursor Time within Region = 0.00
                 </div>
                 <div id="boundaryTime">
-                    Boundary Time = 0.00
+                    Cursor Time within Boundary = 0.00
                 </div>
 
                 <div class="controls">
@@ -74,9 +93,14 @@
                         Pause
                     </button>
 
-                    <button class="btn btn-primary" data-action="update">
-                        Update with new values
-                    </button>
+                    <div class="valButton">
+                        <button class="btn btn-primary" data-action="update">
+                            Update with new values
+                        </button>
+                        <input id="selectionStart" value=0 title="selectionStart" />
+                        <input id="audioStart" value=0 title="audioStart" />
+                        <input id="audioEnd" value=4 title="audioEnd" />
+                    </div>
 
                     <button class="btn btn-primary" data-action="zones">
                         Add zones

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -44,7 +44,7 @@ export class Region {
         this.handleLeftEl = null;
         this.handleRightEl = null;
         this.data = params.data || {};
-        this.attributes = params.attributes || [];
+        this.attributes = params.attributes || {};
         this.showTooltip = params.showTooltip ?? true;
 
         this.maxLength = params.maxLength;

--- a/src/plugin/regions/region.js
+++ b/src/plugin/regions/region.js
@@ -44,7 +44,7 @@ export class Region {
         this.handleLeftEl = null;
         this.handleRightEl = null;
         this.data = params.data || {};
-        this.attributes = params.attributes || {};
+        this.attributes = params.attributes || [];
         this.showTooltip = params.showTooltip ?? true;
 
         this.maxLength = params.maxLength;

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -254,7 +254,6 @@ export default class SelectionPlugin {
             }
         };
         this.maxSelections = 1;
-
         this.selectionsMinLength = params.selectionsMinLength || null;
 
         this.wavesurfer.params.hideBarEnds = params.hideBarEnds || 1;

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -678,7 +678,7 @@ export default class SelectionPlugin {
             scrollDirection = null;
         };
         this.wrapper.addEventListener('mousedown', eventDown);
-        this.wrapper.addEventListener('touchstart', eventDown);
+        this.wrapper.addEventListener('touchstart', eventDown, {passive: true});
         this.on('disable-drag-selection', () => {
             this.wrapper.removeEventListener('touchstart', eventDown);
             this.wrapper.removeEventListener('mousedown', eventDown);

--- a/src/plugin/selection/index.js
+++ b/src/plugin/selection/index.js
@@ -254,6 +254,7 @@ export default class SelectionPlugin {
             }
         };
         this.maxSelections = 1;
+
         this.selectionsMinLength = params.selectionsMinLength || null;
 
         this.wavesurfer.params.hideBarEnds = params.hideBarEnds || 1;

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -46,6 +46,22 @@ export class Region {
         };
         this.regionStyle = params.regionStyle || {};
         this.decoratorStyle = params.decoratorStyle;
+        this.overrideStyle = {
+            subMinimum : {
+                decoratorStyle : {
+                    'border-color' : 'transparent'
+                },
+                handleStyle : {
+                    left : {
+                        display : 'none'
+                    },
+                    right : {
+                        display : 'none'
+                    }
+                }
+            }
+        };
+        this.overrideStyleState = null;
         this.handleLeftEl = null;
         this.handleRightEl = null;
         this.decoratorEl = null;
@@ -54,8 +70,20 @@ export class Region {
         this.showTooltip = params.showTooltip ?? true;
 
         this.maxLength = params.maxLength;
-        // It assumes the minLength parameter value, or the regionsMinLength parameter value, if the first one not provided
+
+        // It assumes the minLength parameter value, or the selectionsMinLength parameter value, if the first one not provided
         this.minLength = params.minLength;
+        // minDisplayLength is an second optional minimum length which only affects rendering
+        this.minDisplayLength = params.minDisplayLength;
+
+        // if we're not given either of these values, default to the other
+        if (!this.minLength) {
+            this.minLength = this.this.minDisplayLength;
+        }
+        if (!this.minDisplayLength) {
+            this.minDisplayLength = this.this.minLength;
+        }
+
         this._onRedraw = () => this.updateRender();
 
         this.scroll = params.scroll !== false && ws.params.scrollParent;
@@ -354,13 +382,19 @@ export class Region {
             startLimited = boundaryDuration - (endLimited - startLimited);
         }
 
-        if (this.minLength != null) {
-            endLimited = Math.max(startLimited + this.minLength, endLimited);
+        if (this.minDisplayLength != null) {
+            endLimited = Math.max(startLimited + this.minDisplayLength, endLimited);
+            if (endLimited - startLimited < this.minLength) {
+                this.attributes['small-bar'] = true;
+            } else {
+                delete this.attributes['small-bar'];
+            }
         }
 
         if (this.maxLength != null) {
             endLimited = Math.min(startLimited + this.maxLength, endLimited);
         }
+
 
         if (this.element != null) {
             // Calculate the left and width values of the region such that

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -805,7 +805,7 @@ export class Region {
         };
 
         this.element.addEventListener('mousedown', onDown);
-        this.element.addEventListener('touchstart', onDown);
+        this.element.addEventListener('touchstart', onDown, {passive: true});
 
         document.body.addEventListener('mousemove', onMove);
         document.body.addEventListener('touchmove', onMove, {passive: false});

--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -46,22 +46,6 @@ export class Region {
         };
         this.regionStyle = params.regionStyle || {};
         this.decoratorStyle = params.decoratorStyle;
-        this.overrideStyle = {
-            subMinimum : {
-                decoratorStyle : {
-                    'border-color' : 'transparent'
-                },
-                handleStyle : {
-                    left : {
-                        display : 'none'
-                    },
-                    right : {
-                        display : 'none'
-                    }
-                }
-            }
-        };
-        this.overrideStyleState = null;
         this.handleLeftEl = null;
         this.handleRightEl = null;
         this.decoratorEl = null;
@@ -395,7 +379,6 @@ export class Region {
             endLimited = Math.min(startLimited + this.maxLength, endLimited);
         }
 
-
         if (this.element != null) {
             // Calculate the left and width values of the region such that
             // no gaps appear between regions.
@@ -422,7 +405,6 @@ export class Region {
             }
         }
     }
-
     /* Bind audio events. */
     bindInOut() {
         this.firedIn = false;


### PR DESCRIPTION
While the minLength is sufficient for not allowing a selection to be dragged smaller than a size, it is possible to set a selection that is smaller than that minimum, and we do want to be able to display those. 

This introduces an optional param `minDisplayLength` which can be set to smaller than the minLength. If the selection is smaller than minLength, but still larger than minDisplayLength, we're applying a data attribute to the region element that can be use for updated styles on the region and controls - e.g. to hide dragging handles. 