### PR TITLE
Adjust boundary-finding logic for small regions

### DIFF
--- a/src/plugin/selection/region.js
+++ b/src/plugin/selection/region.js
@@ -724,7 +724,14 @@ export class Region {
 
                 if (overlapZones) {
                     if (!this.wavesurfer.selection.dragThruZones) {
-                        const bumperValue = nextZoneBoundary({...zoneOverlap, ...overlapZones}, startTime, time - startTime); // the overlapzone that we're bumping up against
+                        /*
+                        * IF the region is larger than the wave (due to minimum region size) then it is possible for the
+                        * startTime to be greater than the end value of the wave.
+                        * Normalize this by adding regionRightHalfTime so that the point used to
+                        * find nextZoneBoundary is always the right edge of the wave itself
+                        */
+                        const point = startTime + regionRightHalfTime;
+                        const bumperValue = nextZoneBoundary({...zoneOverlap, ...overlapZones}, point, time - startTime); // the overlapzone that we're bumping up against
                         // we're dragging right
                         if (time > startTime) {
                             time = bumperValue !== null ? bumperValue - regionRightHalfTime - buffer : time;


### PR DESCRIPTION
Strange interaction sometimes between zone boundaries and dragging a region if the region is larger than the wave (which happens if the wave is smaller than the minimum size of the region). Dragging by starting with mousedown on the part of the region to the right of the wave can cause problems with properly detecting and butting up against zones. 

Imagine a wave and region like this
```
{||||||||||||||||||----------}
 [ wave      ]
[           region             ]     
```

If we start dragging with mouse down in the wave:
```
{||||||||||||||||||----------}
      ^ 
```
.. everything is good. We find the next zone boundary correctly.

If we're dragging starting in the rest of the region
```
{||||||||||||||||||----------}
                        ^
```
.. then (dragging right) we're already past the next zone boundary when the wave starts to overlap with it. 

This PR normalizes the point we use to find the boundary to here:
```
{||||||||||||||||||----------}
                  ^
```